### PR TITLE
add (naive) support for on_conflict_do_update to the query DSL

### DIFF
--- a/sql_query.pl
+++ b/sql_query.pl
@@ -292,6 +292,26 @@ sql_query_insert_on_conflict([Values0|Next], Vars) -->
     ") DO UPDATE ",
     sql_query_insert_do_update_set(Next, Vars).
 
+sql_query_insert_on_conflict([Values0|Next], []) -->
+    { Values0 =.. [on_conflict_do_nothing|Cols] },
+    "ON CONFLICT (",
+    quoted_comma_separated_list(Cols),
+    ") DO NOTHING ",
+    sql_query_insert_returning(Next).
+
+sql_query_insert_on_conflict([on_conflict_do_nothing|Next], []) -->
+    "ON CONFLICT DO NOTHING ",
+    sql_query_insert_returning(Next).
+
+sql_query_insert_on_conflict([Values0], []) -->
+    { Values0 =.. [on_conflict_do_nothing|Cols] },
+    "ON CONFLICT (",
+    quoted_comma_separated_list(Cols),
+    ") DO NOTHING".
+
+sql_query_insert_on_conflict([on_conflict_do_nothing], []) -->
+    "ON CONFLICT DO NOTHING".
+
 sql_query_insert_on_conflict(Rest, []) -->
     sql_query_insert_returning(Rest).
 

--- a/tests.lgt
+++ b/tests.lgt
@@ -6,7 +6,7 @@
     test(trivial) :- true.
     test(password_connection_ok) :- postgresql:connect("postgres", "postgres", '127.0.0.1', 5432, "postgres", _).
     fails(password_connection_fail) :- postgresql:connect("postgres", "invalid", '127.0.0.1', 5432, "postgres", _).
-    
+
     test(create_table_insert_and_select) :-
         postgresql:connect("postgres", "postgres", '127.0.0.1', 5432, "postgres", Connection),
         postgresql:query(Connection, "DROP TABLE IF EXISTS test_table", ok),
@@ -121,6 +121,13 @@
         sql_query:sql_query(
 	    [insert_into(posts, [title, content]), values("Mi nuevo Libro", "Luna de Plutón")],
 	    "INSERT INTO posts (title,content) VALUES ($1,$2)",
+	    [2-"Luna de Plutón", 1-"Mi nuevo Libro"]
+	).
+
+    test(insert_into_on_conflict_do_update) :-
+        sql_query:sql_query(
+	    [insert_into(posts, [title, content]), values("Mi nuevo Libro", "Luna de Plutón"), on_conflict_do_update(title), set(content='EXCLUDED.content')],
+	    "INSERT INTO posts (title,content) VALUES ($1,$2) ON CONFLICT (title) DO UPDATE SET content = EXCLUDED.content",
 	    [2-"Luna de Plutón", 1-"Mi nuevo Libro"]
 	).
 

--- a/tests.lgt
+++ b/tests.lgt
@@ -131,6 +131,20 @@
 	    [2-"Luna de Plutón", 1-"Mi nuevo Libro"]
 	).
 
+    test(insert_into_on_conflict_do_nothing) :-
+        sql_query:sql_query(
+	    [insert_into(posts, [title, content]), values("Mi nuevo Libro", "Luna de Plutón"), on_conflict_do_nothing],
+	    "INSERT INTO posts (title,content) VALUES ($1,$2) ON CONFLICT DO NOTHING",
+	    [2-"Luna de Plutón", 1-"Mi nuevo Libro"]
+	).
+
+    test(insert_into_on_conflict_do_nothing_with_cols) :-
+        sql_query:sql_query(
+	    [insert_into(posts, [title, content]), values("Mi nuevo Libro", "Luna de Plutón"), on_conflict_do_nothing(title)],
+	    "INSERT INTO posts (title,content) VALUES ($1,$2) ON CONFLICT (title) DO NOTHING",
+	    [2-"Luna de Plutón", 1-"Mi nuevo Libro"]
+	).
+
     test(sql_query_update) :-
         sql_query:sql_query(
 	    [update(post),set((lang = "es", price = 99))],


### PR DESCRIPTION
I am attempting to use this library and query DSL to generate some SQL queries, and needed `ON CONFLICT (cols) DO UPDATE` support. Doesn't yet support all cases of this construct (multiple on conflict clauses, or other on conflict actions like do nothing), but I may have those sometime later if I find need for them too.