### PR TITLE
Add SCRAM-SHA-256 authentication

### DIFF
--- a/.github/workflows/test-logtalk.yml
+++ b/.github/workflows/test-logtalk.yml
@@ -1,0 +1,88 @@
+name: Test (Logtalk suite)
+on: [push]
+
+# Scryer Prolog removed Logtalk support after v0.9.x and Logtalk 3.70.0 is the
+# last release shipping the scryer adapter. The Logtalk-driven test set only
+# compiles against that pair, so this job pins both and caches the built
+# scryer-prolog v0.9.4 binary to avoid a 5+ min cargo build on every run.
+
+jobs:
+  test-logtalk:
+    runs-on: ubuntu-22.04
+    services:
+      postgres:
+        image: postgres:16.0-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      SCRYER_VERSION: v0.9.4
+      LOGTALK_VERSION: 3.70.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Cache scryer-prolog ${{ env.SCRYER_VERSION }} binary
+        id: cache-scryer
+        uses: actions/cache@v5
+        with:
+          path: scryer-bin/scryer-prolog
+          key: scryer-prolog-${{ env.SCRYER_VERSION }}-${{ runner.os }}-v1
+
+      - name: Install Rust toolchain
+        if: steps.cache-scryer.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Checkout Scryer Prolog ${{ env.SCRYER_VERSION }}
+        if: steps.cache-scryer.outputs.cache-hit != 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: mthom/scryer-prolog
+          ref: ${{ env.SCRYER_VERSION }}
+          path: scryer-prolog
+
+      - name: Compile Scryer Prolog ${{ env.SCRYER_VERSION }}
+        if: steps.cache-scryer.outputs.cache-hit != 'true'
+        working-directory: scryer-prolog
+        run: |
+          cargo build --release
+          mkdir -p "$GITHUB_WORKSPACE/scryer-bin"
+          cp target/release/scryer-prolog "$GITHUB_WORKSPACE/scryer-bin/scryer-prolog"
+
+      - name: Install Scryer Prolog
+        run: sudo install -m 0755 scryer-bin/scryer-prolog /usr/bin/scryer-prolog
+
+      - name: Install Logtalk ${{ env.LOGTALK_VERSION }}
+        # Inlined to avoid logtalk-actions/setup-logtalk's node16 runtime.
+        # Equivalent to: logtalk-actions/setup-logtalk with logtalk-version: ${LOGTALK_VERSION}.
+        # Extract under $RUNNER_TEMP so logtalk_tester does not pick up the
+        # upstream library/ tester.lgt files and run them all under Scryer.
+        run: |
+          cd "$RUNNER_TEMP"
+          wget -nv "https://logtalk.org/files/logtalk-${LOGTALK_VERSION}.tar.bz2"
+          tar xjf "logtalk-${LOGTALK_VERSION}.tar.bz2"
+          sudo "logtalk-${LOGTALK_VERSION}/scripts/install.sh" -p /usr/local
+          echo "LOGTALKHOME=/usr/local/share/logtalk" >> "$GITHUB_ENV"
+          echo "LOGTALKUSER=$HOME/logtalk" >> "$GITHUB_ENV"
+
+      - name: Execute Logtalk tests
+        # -t 60 bounds each test set so a Scryer hang cannot stall the job near
+        # the GitHub Actions 6h ceiling; -l 1 restricts discovery to this dir.
+        run: logtalk_tester -p scryer -o verbose -l 1 -t 60
+
+      - name: Upload Logtalk tester logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: logtalk-tester-logs
+          path: logtalk_tester_logs/
+          if-no-files-found: ignore

--- a/.github/workflows/test-logtalk.yml
+++ b/.github/workflows/test-logtalk.yml
@@ -61,6 +61,14 @@ jobs:
       - name: Install Scryer Prolog
         run: sudo install -m 0755 scryer-bin/scryer-prolog /usr/bin/scryer-prolog
 
+      - name: First-argument indexing regression (Scryer v0.9.4 - demonstration; allowed to fail)
+        # Demonstrates the bug worked around in types.pl:11-13. The step is
+        # expected to fail on v0.9.4 (shift_* probes return solutions=[]);
+        # continue-on-error keeps the job green. The v0.10.0 counterpart in
+        # the test job asserts the regression is fixed upstream.
+        continue-on-error: true
+        run: scryer-prolog tests/indexing_regression.pl
+
       - name: Install Logtalk ${{ env.LOGTALK_VERSION }}
         # Inlined to avoid logtalk-actions/setup-logtalk's node16 runtime.
         # Equivalent to: logtalk-actions/setup-logtalk with logtalk-version: ${LOGTALK_VERSION}.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,3 +69,22 @@ jobs:
           DATABASE_PASSWORD: postgres
           DATABASE_DB_NAME: postgres
         run: scryer-prolog ./scram_test.pl -g 'run_test'
+
+      # Regression: a downstream consumer that vendors this package as
+      # a submodule runs scryer from the consumer's own CWD, not from
+      # this package root. Any runtime `use_module(Name)` in
+      # postgresql.pl then resolves Name against the consumer's CWD
+      # and throws existence_error(source_sink, "...") on the first
+      # SASL message. Force CWD to be /tmp so the test fails the same
+      # way a consumer would if the regression ever reappears.
+      - name: SCRAM handshake under non-package CWD (consumer simulation)
+        env:
+          DATABASE_HOST: 127.0.0.1
+          DATABASE_PORT: 5433
+          DATABASE_USERNAME: postgres
+          DATABASE_PASSWORD: postgres
+          DATABASE_DB_NAME: postgres
+        run: |
+          REPO=$(pwd)
+          cd /tmp
+          scryer-prolog "$REPO/tests/scram_handshake_cwd_independence_test.pl" -g 'run_test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,20 +5,6 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     services:
-      postgres:
-        image: postgres:16.0-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: password
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
       postgres-scram:
         image: postgres:17-alpine
         env:
@@ -34,25 +20,42 @@ jobs:
           --health-retries 5
         ports:
           - 5433:5432
+    env:
+      SCRYER_VERSION: v0.10.0
     steps:
-      - name: Install Rust cargo
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: cargo
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Checkout Scryer Prolog
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
+
+      - name: Cache scryer-prolog ${{ env.SCRYER_VERSION }} binary
+        id: cache-scryer
+        uses: actions/cache@v5
+        with:
+          path: scryer-bin/scryer-prolog
+          key: scryer-prolog-${{ env.SCRYER_VERSION }}-${{ runner.os }}-v1
+
+      - name: Install Rust toolchain
+        if: steps.cache-scryer.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Checkout Scryer Prolog ${{ env.SCRYER_VERSION }}
+        if: steps.cache-scryer.outputs.cache-hit != 'true'
+        uses: actions/checkout@v6
         with:
           repository: mthom/scryer-prolog
+          ref: ${{ env.SCRYER_VERSION }}
           path: scryer-prolog
-      - name: Compile Scryer Prolog
-        run: cargo build --release
+
+      - name: Compile Scryer Prolog ${{ env.SCRYER_VERSION }}
+        if: steps.cache-scryer.outputs.cache-hit != 'true'
         working-directory: scryer-prolog
+        run: |
+          cargo build --release
+          mkdir -p "$GITHUB_WORKSPACE/scryer-bin"
+          cp target/release/scryer-prolog "$GITHUB_WORKSPACE/scryer-bin/scryer-prolog"
+
       - name: Install Scryer Prolog
-        run: sudo cp scryer-prolog/target/release/scryer-prolog /usr/bin/scryer-prolog
+        run: sudo install -m 0755 scryer-bin/scryer-prolog /usr/bin/scryer-prolog
+
       - name: Execute SCRAM-SHA-256 round-trip test
         env:
           DATABASE_HOST: 127.0.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,21 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      postgres-scram:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+          POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5433:5432
     steps:
       - name: Install Rust cargo
         uses: actions-rs/toolchain@v1
@@ -38,9 +53,11 @@ jobs:
         working-directory: scryer-prolog
       - name: Install Scryer Prolog
         run: sudo cp scryer-prolog/target/release/scryer-prolog /usr/bin/scryer-prolog
-      - name: Install Logtalk
-        uses: logtalk-actions/setup-logtalk@master
-        with:
-          logtalk-version: 3.70.0
-      - name: Execute tests
-        run: logtalk_tester -p scryer
+      - name: Execute SCRAM-SHA-256 round-trip test
+        env:
+          DATABASE_HOST: 127.0.0.1
+          DATABASE_PORT: 5433
+          DATABASE_USERNAME: postgres
+          DATABASE_PASSWORD: postgres
+          DATABASE_DB_NAME: postgres
+        run: scryer-prolog ./scram_test.pl -g 'run_test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Install Scryer Prolog
         run: sudo install -m 0755 scryer-bin/scryer-prolog /usr/bin/scryer-prolog
 
+      - name: First-argument indexing regression (Scryer v0.10.0 - must pass)
+        # Companion check for the workaround in types.pl:11-13.
+        # The bug demonstrated on v0.9.4 lives in the test-logtalk job.
+        run: scryer-prolog tests/indexing_regression.pl
+
       - name: Execute SCRAM-SHA-256 round-trip test
         env:
           DATABASE_HOST: 127.0.0.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Prolog library to connect to PostgreSQL databases
 
 # Installation
 
-The library itself are just four Prolog files (postgresql.pl, sql_query.pl, messages.pl and types.pl). They need to be in the same folder. An easy way to install this library in your project is copying that files. Other way is using Git submodules to get this whole folder, and load the postgresql.pl file from there.
+The library itself is just five Prolog files (`postgresql.pl`, `sql_query.pl`, `messages.pl`, `types.pl`, `scram.pl`). They need to be in the same folder. An easy way to install this library in your project is copying those files. Another way is using Git submodules to get this whole folder, and load the `postgresql.pl` file from there.
 
 ```
 git submodule add https://github.com/aarroyoc/postgresql-prolog postgresql
@@ -20,7 +20,12 @@ The library provides four predicates: `connect/6`, `sql/3`, `query/3` and `query
 ```
 connect(+User, +Password, +Host, +Port, +Database, -Connection)
 ```
-Connects to a PostgreSQL server and tries to authenticate using `password` scheme. This is the only authentication method supported right now. Please, note that this auth method is not the default in some PostgreSQL setups, you changes are needed. If you're running PostgreSQL in Docker, you need to set the environment variable `POSTGRES_HOST_AUTH_METHOD` to `password`.
+Connects to a PostgreSQL server. Authentication method is selected by the server. The library currently supports:
+
+* `password` — AuthenticationCleartextPassword (`R(3)`).
+* `SCRAM-SHA-256` — SASL authentication (`R(10)/R(11)/R(12)`), per RFC 5802 and RFC 7677. This is the default in PostgreSQL 14+ and required by most managed Postgres providers.
+
+No server-side reconfiguration is needed for default-installed PostgreSQL 10+ instances.
 
 ```
 sql(+Connection, +QueryDSL, -Result)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,31 @@
-version: "3.6"
 services:
   postgres:
-    image: postgres:15.3-alpine
+    image: postgres:16-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
-      POSTGRES_HOST_AUTH_METHOD: password
+      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+      POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
     ports:
     - 5432:5432
-    
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+  postgres-scram:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+      POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
+    ports:
+    - 5433:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 3s
+      retries: 30

--- a/justfile
+++ b/justfile
@@ -1,8 +1,19 @@
 test: psql-up && psql-down
-	logtalk_tester -p scryer
+	logtalk_tester -p scryer -o verbose
+
+test-scram: psql-up
+	DATABASE_HOST=127.0.0.1 \
+	DATABASE_PORT=5433 \
+	DATABASE_USERNAME=postgres \
+	DATABASE_PASSWORD=postgres \
+	DATABASE_DB_NAME=postgres \
+	scryer-prolog ./scram_test.pl -g 'run_test'
+
+test-scram: psql-up
+	scryer-prolog ./scram_test.pl -g 'run_test'
 
 psql-up:
-	docker-compose up -d postgres
+	docker-compose up -d postgres postgres-scram
 
 psql-down:
 	docker-compose down

--- a/messages.pl
+++ b/messages.pl
@@ -1,7 +1,10 @@
 :- module(messages, [
     startup_message/3,
     auth_message/2,
+    auth_method/2,
     password_message/2,
+    sasl_initial_response_message/3,
+    sasl_response_message/2,
     auth_ok_message/1,
     query_message/2,
     notice_message/1,
@@ -68,6 +71,60 @@ password_message(Password, Bytes) :-
 % AuthenticationOk
 auth_ok_message(Bytes) :-
     Bytes = [82,0,0,0,8,0,0,0,0]. % Byte R
+
+% auth_method(+Bytes, -Method)
+%
+% Decodes an AuthenticationRequest message into a tagged term. Method is one of:
+%   ok                          - R(0)
+%   password                    - R(3) AuthenticationCleartextPassword
+%   md5(Salt4Bytes)             - R(5) AuthenticationMD5Password
+%   sasl(MechanismList)         - R(10) AuthenticationSASL
+%   sasl_continue(SaslBytes)    - R(11) AuthenticationSASLContinue
+%   sasl_final(SaslBytes)       - R(12) AuthenticationSASLFinal
+auth_method(Bytes, Method) :-
+    Bytes = [82,_L3,_L2,_L1,_L0,C3,C2,C1,C0|Body],
+    int32(Code, [C3,C2,C1,C0]),
+    auth_method_(Code, Body, Method).
+
+auth_method_(0,  _,    ok).
+auth_method_(3,  _,    password).
+auth_method_(5,  Salt, md5(Salt)).
+auth_method_(10, Body, sasl(Mechanisms)) :-
+    nul_terminated_strings(Body, Mechanisms).
+auth_method_(11, Body, sasl_continue(Body)).
+auth_method_(12, Body, sasl_final(Body)).
+
+% NUL-terminated UTF-8 strings, list ended by a final empty string (NUL byte alone).
+nul_terminated_strings([0], []) :- !.
+nul_terminated_strings(Bytes, [Chars|Rest]) :-
+    append(StringBytes, [0|After], Bytes),
+    \+ member(0, StringBytes),
+    !,
+    chars_utf8bytes(Chars, StringBytes),
+    nul_terminated_strings(After, Rest).
+
+% SASLInitialResponse (F)
+%   Byte1('p'), Int32(length), String(mechanism), Int32(initial-response-length), Bytes(initial-response)
+sasl_initial_response_message(Mechanism, ClientFirst, Bytes) :-
+    pstring(Mechanism, MechBytes),
+    chars_utf8bytes(ClientFirst, ClientFirstBytes),
+    length(ClientFirstBytes, ClientFirstLen),
+    int32(ClientFirstLen, ClientFirstLenBytes),
+    append(MechBytes, ClientFirstLenBytes, MechAndLen),
+    append(MechAndLen, ClientFirstBytes, PreBytes),
+    length(PreBytes, L),
+    RealLength is L + 4,
+    int32(RealLength, LengthBytes),
+    append([112|LengthBytes], PreBytes, Bytes).
+
+% SASLResponse (F)
+%   Byte1('p'), Int32(length), Bytes(client-final)
+sasl_response_message(ClientFinal, Bytes) :-
+    chars_utf8bytes(ClientFinal, ClientFinalBytes),
+    length(ClientFinalBytes, L),
+    RealLength is L + 4,
+    int32(RealLength, LengthBytes),
+    append([112|LengthBytes], ClientFinalBytes, Bytes).
 
 % Query
 query_message(Query, Bytes) :-

--- a/postgresql.pl
+++ b/postgresql.pl
@@ -7,9 +7,27 @@
 
 
 :- use_module(messages).
-:- use_module(scram, [do_scram_sha_256_after_offer/3]).
+% scram.pl pulls in library(crypto), whose eager load makes the Logtalk
+% test suite hang under Scryer 0.9.4 + Logtalk 3.70.0 (the pair this repo
+% pins for that job, since Scryer >= 0.10 dropped the Logtalk adapter).
+% Load scram lazily, but anchor its path at compile time so the resolution
+% does not depend on the consumer's runtime CWD (a regression we hit when
+% this package is vendored as a submodule -- see
+% tests/scram_handshake_cwd_independence_test.pl).
 :- use_module(sql_query).
 :- use_module(types).
+
+:- dynamic(scram_module_path/1).
+
+capture_scram_module_path :-
+    catch(
+        ( prolog_load_context(directory, Dir),
+          atom_concat(Dir, '/scram.pl', Path),
+          assertz(scram_module_path(Path)) ),
+        _,
+        true
+    ).
+:- initialization(capture_scram_module_path).
 
 connect(User, Password, Host, Port, Database, postgresql(Stream)) :-
     (   atom(Host)
@@ -34,8 +52,10 @@ handle_auth(password, Stream, _, Password) :-
     get_bytes(Stream, BytesOk),
     auth_ok_message(BytesOk).
 handle_auth(sasl(Mechanisms), Stream, User, Password) :-
+    scram_module_path(Path),
+    use_module(Path, [do_scram_sha_256_after_offer/3]),
     if_(memberd_t("SCRAM-SHA-256", Mechanisms),
-        ( do_scram_sha_256_after_offer(Stream, User, Password),
+        ( scram:do_scram_sha_256_after_offer(Stream, User, Password),
           get_bytes(Stream, BytesOk),
           auth_ok_message(BytesOk)
         ),

--- a/postgresql.pl
+++ b/postgresql.pl
@@ -3,23 +3,44 @@
 :- use_module(library(lists)).
 :- use_module(library(charsio)).
 :- use_module(library(sockets)).
+:- use_module(library(reif)).
 
 
-:- use_module('messages').
-:- use_module('sql_query').
-:- use_module('types').
+:- use_module(messages).
+:- use_module(scram, [do_scram_sha_256_after_offer/3]).
+:- use_module(sql_query).
+:- use_module(types).
 
 connect(User, Password, Host, Port, Database, postgresql(Stream)) :-
-    socket_client_open(Host:Port, Stream, [type(binary)]),
+    (   atom(Host)
+    ->  HostAtom = Host
+    ;   atom_chars(HostAtom, Host) ),
+    socket_client_open(HostAtom:Port, Stream, [type(binary)]),
     startup_message(User, Database, BytesStartup),
     put_bytes(Stream, BytesStartup),
+    do_authenticate(Stream, User, Password),
+    flush_bytes(Stream).
+
+% Dispatch on the server's AuthenticationRequest method.
+do_authenticate(Stream, User, Password) :-
     get_bytes(Stream, BytesAuth),
-    auth_message(password, BytesAuth),
+    auth_method(BytesAuth, Method),
+    handle_auth(Method, Stream, User, Password).
+
+handle_auth(ok, _, _, _).
+handle_auth(password, Stream, _, Password) :-
     password_message(Password, BytesPassword),
     put_bytes(Stream, BytesPassword),
     get_bytes(Stream, BytesOk),
-    auth_ok_message(BytesOk),
-    flush_bytes(Stream).
+    auth_ok_message(BytesOk).
+handle_auth(sasl(Mechanisms), Stream, User, Password) :-
+    if_(memberd_t("SCRAM-SHA-256", Mechanisms),
+        ( do_scram_sha_256_after_offer(Stream, User, Password),
+          get_bytes(Stream, BytesOk),
+          auth_ok_message(BytesOk)
+        ),
+        throw(unsupported_sasl_mechanisms(Mechanisms))
+    ).
 
 flush_bytes(Stream) :-
     get_bytes(Stream, Bytes),

--- a/scram.pl
+++ b/scram.pl
@@ -1,0 +1,311 @@
+:- module(scram, [do_scram_sha_256_after_offer/3]).
+
+/**
+SCRAM-SHA-256 SASL authentication for the PostgreSQL wire protocol.
+
+Implements the client side of the SASL exchange specified by
+[RFC 5802](https://www.rfc-editor.org/rfc/rfc5802) and
+[RFC 7677](https://www.rfc-editor.org/rfc/rfc7677), as carried by
+PostgreSQL's `AuthenticationSASL` / `AuthenticationSASLContinue` /
+`AuthenticationSASLFinal` messages.
+
+The handshake exchanges four SASL messages:
+
+- *client-first* (`SASLInitialResponse`) carrying the client nonce
+- *server-first* (`R(11) AuthenticationSASLContinue`) with the combined
+  nonce, salt and iteration count
+- *client-final* (`SASLResponse`) carrying the client proof
+- *server-final* (`R(12) AuthenticationSASLFinal`) with the server signature
+
+The module uses `gs2-cbind-flag = "n"` (no channel binding) and omits the
+authzid, so the GS2 header is `n,,` and the base64 channel binding is
+`biws`. Cryptographic primitives come from `library(crypto)`; PBKDF2 is
+implemented locally on top of `hmac_sha256/3`.
+*/
+
+:- use_module(library(charsio)).
+:- use_module(library(crypto)).
+:- use_module(library(lists)).
+:- use_module(library(format)).
+:- use_module(library(dcgs)).
+:- use_module(library(reif)).
+
+:- use_module(messages, [
+    auth_method/2,
+    sasl_initial_response_message/3,
+    sasl_response_message/2
+]).
+
+% Reads bytes from Stream the same way postgresql.pl get_bytes/2 does.
+:- use_module(types, [int32/2]).
+
+% ---------- SCRAM message grammar (RFC 5802 §7) ------------------
+% We use gs2-cbind-flag = "n" (no channel binding) and omit authzid,
+% so gs2-header = "n,," and channel-binding base64 = "biws".
+% Each rule below mirrors one ABNF production.
+
+client_first_message(User, Nonce) -->
+    gs2_header,
+    client_first_message_bare(User, Nonce).
+
+gs2_header --> "n,,".
+
+client_first_message_bare(User, Nonce) -->
+    username(User), ",", nonce(Nonce).
+
+username(SaslName) --> "n=", seq(SaslName).
+nonce(Printable)   --> "r=", seq(Printable).
+
+channel_binding --> "c=biws".
+
+client_final_message_without_proof(Nonce) -->
+    channel_binding, ",", nonce(Nonce).
+
+proof(Base64) --> "p=", seq(Base64).
+
+client_final_message(Nonce, Base64Proof) -->
+    client_final_message_without_proof(Nonce), ",", proof(Base64Proof).
+
+% AuthMessage = client-first-message-bare "," server-first-message ","
+%               client-final-message-without-proof
+auth_message(User, ClientNonce, ServerFirst, CombinedNonce) -->
+    client_first_message_bare(User, ClientNonce), ",",
+    seq(ServerFirst), ",",
+    client_final_message_without_proof(CombinedNonce).
+
+%% do_scram_sha_256_after_offer(+Stream, +User, +Password)
+%
+% Performs SCRAM-SHA-256 SASL authentication on a PostgreSQL wire-protocol
+% `Stream` that has just received an `R(10) AuthenticationSASL` message
+% advertising `SCRAM-SHA-256`.
+%
+% Sends `SASLInitialResponse` with the client-first message, parses the
+% server-first message returned in `R(11)`, derives the salted password via
+% PBKDF2-HMAC-SHA-256, sends the client proof in `SASLResponse`, and finally
+% verifies the server signature returned in `R(12) AuthenticationSASLFinal`.
+%
+% On success the stream is left positioned to read the next
+% `R(0) AuthenticationOk`, after which the caller should proceed to
+% `ReadyForQuery`.
+%
+% Throws:
+%
+% - `scram_invalid_server_nonce` when the combined nonce does not extend the
+%   client nonce
+% - `scram_server_signature_mismatch` when the server signature does not match
+%   the value expected from `ServerKey`
+% - `scram_server_error(Err)` when the server reports an `e=<error>` in the
+%   final message
+%
+% References:
+%
+% - [RFC 5802](https://www.rfc-editor.org/rfc/rfc5802) (SCRAM)
+% - [RFC 7677](https://www.rfc-editor.org/rfc/rfc7677) (SCRAM-SHA-256)
+% - PostgreSQL protocol: SASL Authentication
+do_scram_sha_256_after_offer(Stream, User, Password) :-
+    % --- client-first-message ---
+    client_nonce_chars(ClientNonce),
+    phrase(client_first_message(User, ClientNonce), ClientFirst),
+
+    sasl_initial_response_message("SCRAM-SHA-256", ClientFirst, InitBytes),
+    put_bytes(Stream, InitBytes),
+
+    % --- server-first-message in R(11) ---
+    get_message_bytes(Stream, ContinueMsg),
+    auth_method(ContinueMsg, sasl_continue(ServerFirstBytes)),
+    chars_utf8bytes(ServerFirst, ServerFirstBytes),
+    parse_server_first(ServerFirst, ServerNonce, SaltBytes, Iterations),
+
+    % Sanity: server must echo our client nonce as a prefix.
+    (   append(ClientNonce, _, ServerNonce)
+    ->  true
+    ;   throw(scram_invalid_server_nonce) ),
+
+    % --- compute keys ---
+    chars_utf8bytes(Password, PasswordBytes),
+    pbkdf2_hmac_sha256(PasswordBytes, SaltBytes, Iterations, 32, SaltedPassword),
+
+    hmac_sha256(SaltedPassword, "Client Key", ClientKey),
+    sha256_bytes(ClientKey, StoredKey),
+
+    % AuthMessage = client-first-message-bare "," server-first-message ","
+    %               client-final-message-without-proof  (RFC 5802 §3)
+    phrase(auth_message(User, ClientNonce, ServerFirst, ServerNonce), AuthMessageChars),
+
+    hmac_sha256(StoredKey, AuthMessageChars, ClientSignature),
+    bytes_xor(ClientKey, ClientSignature, ClientProof),
+
+    bytes_to_chars(ClientProof, ClientProofChars),
+    chars_base64(ClientProofChars, ClientProofB64, []),
+
+    phrase(client_final_message(ServerNonce, ClientProofB64), ClientFinal),
+
+    sasl_response_message(ClientFinal, FinalBytes),
+    put_bytes(Stream, FinalBytes),
+
+    % --- server-final-message in R(12) ---
+    get_message_bytes(Stream, FinalMsg),
+    auth_method(FinalMsg, sasl_final(ServerFinalBytes)),
+    chars_utf8bytes(ServerFinal, ServerFinalBytes),
+    parse_server_final(ServerFinal, ServerSigB64),
+    chars_base64(ServerSigChars, ServerSigB64, []),
+    chars_to_bytes(ServerSigChars, ServerSigBytes),
+
+    % Verify server signature
+    hmac_sha256(SaltedPassword, "Server Key", ServerKey),
+    hmac_sha256(ServerKey, AuthMessageChars, ExpectedServerSig),
+
+    if_(dif(ServerSigBytes, ExpectedServerSig),
+        throw(scram_server_signature_mismatch),
+        true
+    ).
+
+
+% ---------------------------------------------------------------- helpers
+
+%% get_message_bytes(+Stream, -Bytes)
+%
+% Reads a single PostgreSQL protocol message from `Stream` as the byte list
+% `[TypeByte, L3, L2, L1, L0, Body...]`, where the `int32(L3..L0)` length
+% includes itself but not the type byte.
+get_message_bytes(Stream, Bytes) :-
+    get_byte(Stream, BType),
+    get_byte(Stream, B3),
+    get_byte(Stream, B2),
+    get_byte(Stream, B1),
+    get_byte(Stream, B0),
+    int32(Length, [B3,B2,B1,B0]),
+    Remaining is Length - 4,
+    get_n_bytes(Stream, Remaining, Body),
+    append([BType,B3,B2,B1,B0], Body, Bytes).
+
+get_n_bytes(_, 0, []) :- !.
+get_n_bytes(Stream, N, [B|Bs]) :-
+    N > 0,
+    get_byte(Stream, B),
+    N1 is N - 1,
+    get_n_bytes(Stream, N1, Bs).
+
+put_bytes(_, []).
+put_bytes(Stream, [B|Bs]) :-
+    put_byte(Stream, B),
+    put_bytes(Stream, Bs).
+
+%% client_nonce_chars(-Nonce)
+%
+% A printable-ASCII nonce: 18 random bytes base64-encoded with the URL
+% charset and no padding (24 chars, no `/`).
+client_nonce_chars(Nonce) :-
+    crypto_n_random_bytes(18, RandBytes),
+    bytes_to_chars(RandBytes, RandChars),
+    chars_base64(RandChars, NonceWithMaybeSlash, [padding(false), charset(url)]),
+    Nonce = NonceWithMaybeSlash.
+
+bytes_to_chars([], []).
+bytes_to_chars([B|Bs], [C|Cs]) :- char_code(C, B), bytes_to_chars(Bs, Cs).
+
+chars_to_bytes([], []).
+chars_to_bytes([C|Cs], [B|Bs]) :- char_code(C, B), chars_to_bytes(Cs, Bs).
+
+%% bytes_xor(+As, +Bs, -Cs)
+%
+% Element-wise XOR of two byte lists of equal length: `C[i] = A[i] xor B[i]`.
+bytes_xor([], [], []).
+bytes_xor([A|As], [B|Bs], [C|Cs]) :-
+    C is xor(A, B),
+    bytes_xor(As, Bs, Cs).
+
+%% sha256_bytes(+InputBytes, -OutputBytes)
+%
+% SHA-256 over a byte list, returning the 32-byte digest as a byte list.
+sha256_bytes(InputBytes, OutputBytes) :-
+    bytes_to_chars(InputBytes, InputChars),
+    crypto_data_hash(InputChars, Hex, [algorithm(sha256), encoding(octet)]),
+    hex_bytes(Hex, OutputBytes).
+
+%% hmac_sha256(+KeyBytes, +Data, -MacBytes)
+%
+% HMAC-SHA-256 with key `KeyBytes` (a byte list) over `Data`. `Data` may be
+% either a list of chars or a list of bytes (0..255); byte input is converted
+% to octet-chars before being fed to `crypto_data_hash/3` with
+% `encoding(octet)`.
+hmac_sha256(KeyBytes, DataChars, MacBytes) :-
+    (   data_is_bytes(DataChars)
+    ->  bytes_to_chars(DataChars, OctetChars)
+    ;   OctetChars = DataChars ),
+    crypto_data_hash(OctetChars, Hex, [algorithm(sha256), hmac(KeyBytes), encoding(octet)]),
+    hex_bytes(Hex, MacBytes).
+
+%% data_is_bytes(+List)
+%
+% Succeeds when `List` looks like a byte list: a non-empty list whose first
+% element is an integer in `0..255`. Used by `hmac_sha256/3` to decide whether
+% to convert input to octet-chars.
+data_is_bytes([H|_]) :- integer(H), H >= 0, H =< 255.
+
+%% pbkdf2_hmac_sha256(+PasswordBytes, +SaltBytes, +Iterations, +DkLen, -DK)
+%
+% PBKDF2 with HMAC-SHA-256 as the underlying PRF, per
+% [RFC 8018](https://www.rfc-editor.org/rfc/rfc8018). Only `DkLen = 32` (a
+% single output block) is supported, which is what SCRAM-SHA-256 requires.
+pbkdf2_hmac_sha256(Password, Salt, Iterations, 32, DK) :-
+    int32_be_bytes(1, IndexBytes),
+    append(Salt, IndexBytes, FirstBlockInput),
+    hmac_sha256(Password, FirstBlockInput, U1),
+    pbkdf2_iterate(Password, U1, U1, Iterations, 1, DK).
+
+pbkdf2_iterate(_, _, Acc, MaxIter, MaxIter, Acc) :- !.
+pbkdf2_iterate(Password, Prev, Acc, MaxIter, I, DK) :-
+    I < MaxIter,
+    hmac_sha256(Password, Prev, Next),
+    bytes_xor(Acc, Next, Acc1),
+    I1 is I + 1,
+    pbkdf2_iterate(Password, Next, Acc1, MaxIter, I1, DK).
+
+%% int32_be_bytes(+N, -Bytes)
+%
+% Encodes a 32-bit non-negative integer `N` as a big-endian 4-byte list.
+int32_be_bytes(N, [B3,B2,B1,B0]) :-
+    B0 is N /\ 255,
+    B1 is (N >> 8) /\ 255,
+    B2 is (N >> 16) /\ 255,
+    B3 is (N >> 24) /\ 255.
+
+%% parse_server_first(+Chars, -CombinedNonce, -SaltBytes, -Iterations)
+%
+% Parses a server-first message of the form
+% `r=<nonce>,s=<base64-salt>,i=<iter>`, returning the combined nonce, the
+% decoded salt as bytes, and the iteration count as an integer. The optional
+% `m=` mandatory-extensions attribute is ignored if present.
+parse_server_first(Chars, Nonce, SaltBytes, Iterations) :-
+    split_on(Chars, ',', Parts),
+    member(NoncePart, Parts), append("r=", Nonce, NoncePart), !,
+    member(SaltPart, Parts), append("s=", SaltB64, SaltPart), !,
+    member(IterPart, Parts), append("i=", IterChars, IterPart), !,
+    chars_base64(SaltChars, SaltB64, []),
+    chars_to_bytes(SaltChars, SaltBytes),
+    number_chars(Iterations, IterChars).
+
+%% parse_server_final(+Chars, -ServerSigB64)
+%
+% On success, extracts the `v=<base64-signature>` server signature from a
+% server-final message. Throws `scram_server_error(Err)` when the server
+% reported an `e=<error>` instead.
+parse_server_final(Chars, ServerSigB64) :-
+    split_on(Chars, ',', Parts),
+    (   member(EPart, Parts), append("e=", Err, EPart)
+    ->  throw(scram_server_error(Err))
+    ;   true ),
+    member(VPart, Parts), append("v=", ServerSigB64, VPart), !.
+
+%% split_on(+Chars, +SepChar, -Parts)
+%
+% Splits the char list `Chars` on every occurrence of `SepChar`, producing
+% `Parts` as the list of separator-free segments (a trailing empty segment is
+% omitted because the base case returns the remainder as a single part).
+split_on(Chars, Sep, [Part|Rest]) :-
+    append(Part, [Sep|Tail], Chars),
+    \+ member(Sep, Part),
+    !,
+    split_on(Tail, Sep, Rest).
+split_on(Chars, _, [Chars]).

--- a/scram_test.pl
+++ b/scram_test.pl
@@ -1,0 +1,36 @@
+:- module(scram_test, [run_test/0]).
+
+:- use_module(library(format)).
+:- use_module(library(lists)).
+:- use_module(library(os)).
+
+:- use_module('postgresql', [connect/6, query/3]).
+
+%% env_or_default(+Name, +Default, -Value)
+env_or_default(Name, Default, Value) :-
+    (   getenv(Name, V)
+    ->  Value = V
+    ;   Value = Default ).
+
+%% run_test/0
+%
+% Boots a connection to the docker-compose Postgres using SCRAM-SHA-256
+% and runs a trivial SELECT. Exits 0 on success, 1 on failure, 2 on
+% setup error.
+run_test :-
+    env_or_default("DATABASE_HOST",     "127.0.0.1", Host),
+    env_or_default("DATABASE_PORT",     "5433",      PortChars),
+    number_chars(Port, PortChars),
+    env_or_default("DATABASE_USERNAME", "postgres",  User),
+    env_or_default("DATABASE_PASSWORD", "postgres",  Pass),
+    env_or_default("DATABASE_DB_NAME",  "postgres",  DB),
+
+    format("[..] connecting to ~s:~d as ~s -> ~s~n", [Host, Port, User, DB]),
+    connect(User, Pass, Host, Port, DB, Conn),
+    format("[ok] handshake completed (SCRAM-SHA-256)~n", []),
+
+    query(Conn, "SELECT 'scram-sha-256 ok'::text", Result),
+    (   Result = data(_Headers, [["scram-sha-256 ok"]])
+    ->  format("[OK] scram_test passed~n", []), halt(0)
+    ;   format("[KO] unexpected result shape: ~w~n", [Result]), halt(1)
+    ).

--- a/tests/indexing_regression.pl
+++ b/tests/indexing_regression.pl
@@ -1,0 +1,68 @@
+:- use_module(library(format)).
+:- use_module(library(lists)).
+
+% Regression test for the first-argument indexing bug in Scryer 0.9.4
+% that motivated the multiplication-based decoding in types.pl
+% (int32/2 and int16/2 -- see the comment at types.pl:11-13).
+%
+% On Scryer 0.9.4, integers produced by `<<` carry a tag that the
+% indexed dispatch of multiclause predicates such as auth_method_/3
+% fails to match, so the `shift_*` probes below report `solutions=[]`
+% even though the numeric value is correct. The `mul_*` probes succeed
+% because multiplication keeps the result in the fixnum representation
+% the clause-head literals were compiled against.
+%
+% On Scryer 0.10.0 the regression is fixed: both formulations dispatch
+% correctly and every probe reports its expected solution. When 0.10.0
+% becomes the supported minimum, the multiplication workaround in
+% types.pl can be reverted to the natural `<<` form.
+%
+% Run with:
+%   scryer-prolog tests/indexing_regression.pl
+%
+% Reproduces the int32/2 decoding both ways: with `<<` (indexing-breaking
+% representation on 0.9.4) and with `*` (workaround used in types.pl).
+int32_shift(N, [B3,B2,B1,B0]) :-
+    N is (B3 << 24) + (B2 << 16) + (B1 << 8) + B0.
+
+int32_mul(N, [B3,B2,B1,B0]) :-
+    N is B3*16777216 + B2*65536 + B1*256 + B0.
+
+% Same clause shape as auth_method_/3 in messages.pl.
+am_(0,  _,    ok).
+am_(3,  _,    password).
+am_(5,  Salt, md5(Salt)).
+am_(10, Body, sasl(Body)).
+am_(11, Body, sasl_continue(Body)).
+am_(12, Body, sasl_final(Body)).
+
+:- dynamic(probe_failed/1).
+
+probe(Label, Decoder, Bytes, Expected) :-
+    call(Decoder, N, Bytes),
+    findall(M, am_(N, [], M), Ms),
+    (   Ms = [Sol], \+ \+ Sol = Expected
+    ->  Status = pass
+    ;   Status = fail,
+        assertz(probe_failed(Label))
+    ),
+    format("~w: bytes=~w -> N=~w, solutions=~w, expected=~w [~w]~n",
+           [Label, Bytes, N, Ms, [Expected], Status]).
+
+run :-
+    probe(shift_00, int32_shift, [0,0,0,0],  ok),
+    probe(mul_00,   int32_mul,   [0,0,0,0],  ok),
+    probe(shift_03, int32_shift, [0,0,0,3],  password),
+    probe(mul_03,   int32_mul,   [0,0,0,3],  password),
+    probe(shift_05, int32_shift, [0,0,0,5],  md5(_)),
+    probe(mul_05,   int32_mul,   [0,0,0,5],  md5(_)),
+    probe(shift_10, int32_shift, [0,0,0,10], sasl(_)),
+    probe(mul_10,   int32_mul,   [0,0,0,10], sasl(_)),
+    findall(L, probe_failed(L), Failures),
+    (   Failures == []
+    ->  format("~nALL PROBES PASSED~n", [])
+    ;   format("~nFAILED PROBES: ~w~n", [Failures]),
+        fail
+    ).
+
+:- initialization((run -> halt(0) ; halt(1))).

--- a/tests/scram_handshake_cwd_independence_test.pl
+++ b/tests/scram_handshake_cwd_independence_test.pl
@@ -1,0 +1,65 @@
+:- module(scram_handshake_cwd_independence_test, [run_test/0]).
+
+:- use_module(library(format)).
+:- use_module(library(lists)).
+:- use_module(library(os)).
+
+:- use_module('../postgresql', [connect/6, query/3]).
+
+/*
+Regression: SCRAM handshake must succeed when scryer-prolog is
+invoked with a current working directory other than this package's
+own root.
+
+The shipping scram_test.pl runs from the package root, so any
+relative-path `use_module(_)` call inside postgresql.pl trivially
+resolves -- the package files are right next to CWD. That hides a
+real failure mode: consumers (e.g. a downstream project that
+vendors postgresql-prolog as a submodule under deps/) run scryer
+from the consumer's own root, with CWD != this package. Any
+runtime `use_module(Name)` inside postgresql.pl then tries to
+open `<consumer-cwd>/Name.pl` and throws
+
+    error(existence_error(source_sink, "scram.pl"), open/4)
+
+on the very first SASL `AuthenticationSASL` message.
+
+This test imports postgresql via the same kind of relative-prefix
+path a consumer would use, and the justfile / CI invocation runs
+it with `cd /tmp && scryer-prolog ...` so the CWD is *not* the
+package root. A green result here means the SCRAM module is
+resolved at compile time (when relative paths are anchored to the
+calling .pl file), not at runtime (when they are anchored to CWD).
+*/
+
+env_or_default(Name, Default, Value) :-
+    (   getenv(Name, V)
+    ->  Value = V
+    ;   Value = Default ).
+
+run_test :-
+    env_or_default("DATABASE_HOST",     "127.0.0.1", Host),
+    env_or_default("DATABASE_PORT",     "5433",      PortChars),
+    number_chars(Port, PortChars),
+    env_or_default("DATABASE_USERNAME", "postgres",  User),
+    env_or_default("DATABASE_PASSWORD", "postgres",  Pass),
+    env_or_default("DATABASE_DB_NAME",  "postgres",  DB),
+
+    format("[..] connecting to ~s:~d as ~s -> ~s (CWD != package root)~n",
+           [Host, Port, User, DB]),
+
+    catch(
+        connect(User, Pass, Host, Port, DB, Conn),
+        E,
+        ( format("[KO] connect/6 threw during SCRAM handshake: ~q~n", [E]),
+          format("     (this is the runtime use_module(scram) bug)~n", []),
+          halt(1) )
+    ),
+
+    query(Conn, "SELECT 'scram-sha-256 ok'::text", Result),
+    (   Result = data(_Headers, [["scram-sha-256 ok"]])
+    ->  format("[OK] SCRAM handshake survives a non-package CWD~n", []),
+        halt(0)
+    ;   format("[KO] unexpected query result shape: ~w~n", [Result]),
+        halt(1)
+    ).

--- a/types.pl
+++ b/types.pl
@@ -8,7 +8,12 @@
 
 int32(Number, [B3, B2, B1, B0]) :-
     var(Number),
-    Number is (B3 << 24) + (B2 << 16) + (B1 << 8) + B0.
+    % Multiplication rather than `<<` because Scryer 0.9.4 returns integers
+    % from bitshift expressions whose representation breaks first-argument
+    % indexing on the receiving multiclause predicate (auth_method_/3).
+    % See tests/indexing_regression.pl for a reproducer; the bug is fixed
+    % in Scryer 0.10.0.
+    Number is B3 * 16777216 + B2 * 65536 + B1 * 256 + B0.
 
 int32(Number, [B3, B2, B1, B0]) :-
     integer(Number),
@@ -19,7 +24,7 @@ int32(Number, [B3, B2, B1, B0]) :-
 
 int16(Number, [B1, B0]) :-
     var(Number),
-    Number is (B1 << 8) + B0.
+    Number is B1 * 256 + B0.
 
 int16(Number, [B1, B0]) :-
     integer(Number),


### PR DESCRIPTION
Hello @aarroyoc 👋🏼,

I needed to connect to a PostgreSQL instance via SCRAM-SHA-256 authentication.

I thought you might be interested in this implementation.

I've noticed that Logtalk suite didn't work anymore with the most recent version of Scryer Prolog so I've tried to keep the suite separate.

Please let me know if you'd like to see something done differently.

## Summary

- Implements SCRAM-SHA-256 SASL auth (RFC 5802 + RFC 7677) so the library can connect to default-configured PostgreSQL 10+ servers and managed providers that no longer accept cleartext password auth.
- `messages.pl`: decode `AuthenticationRequest` into a tagged term (`ok` / `password` / `md5/1` / `sasl/1` / `sasl_continue/1` / `sasl_final/1`); add SASL response builders.
- `scram.pl` (new): SCRAM-SHA-256 client with PBKDF2-HMAC-SHA-256 implemented on top of `library(crypto)`. No new external dependencies.
- `connect/6` reads the first auth response and dispatches: `ok` → done, `password` → existing cleartext path (unchanged), `sasl(_)` → SCRAM-SHA-256 when offered. The existing cleartext flow is preserved; backward compatibility is decided at runtime by the server's auth-method byte.

## Test plan

- Local: `just psql-up` boots both postgres:16-alpine (password) and postgres:17-alpine (scram-sha-256); 
  `just test-scram` runs the round-trip against the SCRAM instance on port 5433.
- CI: existing Logtalk suite continues to run against the `postgres:16-alpine` password service; a second `postgres:17-alpine` scram service runs the SCRAM smoke test side by side.
